### PR TITLE
Step2 Proxy와 Bean 의존관계

### DIFF
--- a/di/build.gradle
+++ b/di/build.gradle
@@ -17,11 +17,13 @@ repositories {
 dependencies {
     implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api:2.1.1'
+    implementation project(':aop')
 
     implementation 'org.reflections:reflections:0.10.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
     implementation 'ch.qos.logback:logback-classic:1.5.6'
     implementation 'org.apache.commons:commons-lang3:3.14.0'
+    implementation 'cglib:cglib:3.3.0'
 
     testImplementation 'org.assertj:assertj-core:3.26.0'
     testImplementation 'org.mockito:mockito-core:5.12.0'

--- a/di/src/main/java/com/interface21/beans/BeanProxyInterceptor.java
+++ b/di/src/main/java/com/interface21/beans/BeanProxyInterceptor.java
@@ -1,0 +1,34 @@
+package com.interface21.beans;
+
+import com.interface21.beans.factory.BeanFactory;
+import net.sf.cglib.proxy.MethodInterceptor;
+import net.sf.cglib.proxy.MethodProxy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+
+public class BeanProxyInterceptor implements MethodInterceptor {
+    private static final Logger logger = LoggerFactory.getLogger(BeanProxyInterceptor.class);
+
+    private Class<?> type;
+    private BeanFactory beanFactory;
+    private Object target;
+
+    public BeanProxyInterceptor(Class<?> type, BeanFactory beanFactory, Object target) {
+        this.type = type;
+        this.beanFactory = beanFactory;
+        this.target = target;
+    }
+
+    @Override
+    public Object intercept(Object obj, Method method, Object[] args, MethodProxy proxy) throws Throwable {
+        if (target == null) {
+            logger.info("빈 초기화");
+            target = beanFactory.getBean(type);
+        }
+
+        logger.info("프록시 메소드 동작");
+        return method.invoke(this.target, args);
+    }
+}

--- a/di/src/main/java/com/interface21/beans/DefaultFactoryBean.java
+++ b/di/src/main/java/com/interface21/beans/DefaultFactoryBean.java
@@ -1,0 +1,26 @@
+package com.interface21.beans;
+
+import com.interface21.beans.factory.FactoryBean;
+import net.sf.cglib.proxy.Enhancer;
+import net.sf.cglib.proxy.MethodInterceptor;
+
+public class DefaultFactoryBean implements FactoryBean {
+    private Class<?> type;
+    private MethodInterceptor methodInterceptor;
+
+    public DefaultFactoryBean(
+            Class<?> type,
+            MethodInterceptor methodInterceptor
+    ) {
+        this.methodInterceptor = methodInterceptor;
+        this.type = type;
+    }
+
+    @Override
+    public Object getObject() throws Exception {
+        Enhancer enhancer = new Enhancer();
+        enhancer.setSuperclass(type);
+        enhancer.setCallback(methodInterceptor);
+        return enhancer.create();
+    }
+}

--- a/di/src/test/java/com/interface21/context/support/AnnotationConfigWebApplicationContextTest.java
+++ b/di/src/test/java/com/interface21/context/support/AnnotationConfigWebApplicationContextTest.java
@@ -1,14 +1,34 @@
 package com.interface21.context.support;
 
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import com.interface21.beans.BeanProxyInterceptor;
+import com.interface21.beans.DefaultFactoryBean;
 import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import ch.qos.logback.classic.Logger;
+import org.slf4j.LoggerFactory;
 import samples.DatasourceConfiguration;
+import samples.SampleController;
+import samples.SampleService;
+import samples.TestConfiguration;
 
 import javax.sql.DataSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AnnotationConfigWebApplicationContextTest {
+    private TestAppender testAppender;
+
+    @BeforeEach
+    public void setUp() {
+        Logger logger = (Logger) LoggerFactory.getLogger(BeanProxyInterceptor.class);
+        testAppender = new TestAppender();
+        logger.addAppender(testAppender);
+        testAppender.start();
+    }
 
     @Test
     void configuration() {
@@ -16,5 +36,28 @@ class AnnotationConfigWebApplicationContextTest {
         final var dataSource = applicationContext.getBean(DataSource.class);
         assertThat(dataSource).isInstanceOf(DataSource.class);
         assertThat(dataSource).isInstanceOf(JdbcDataSource.class);
+    }
+
+    @Test
+    void 프록시객체테스트() {
+        final var applicationContext = new AnnotationConfigWebApplicationContext(TestConfiguration.class);
+        final var sampleController = applicationContext.getBean(SampleController.class);
+        assertThat(sampleController.getSampleService()).isInstanceOf(SampleService.class);
+        sampleController.hello();
+
+        assertTrue(testAppender.contains("프록시 메소드 동작"));
+    }
+
+    static class TestAppender extends AppenderBase<ILoggingEvent> {
+        private StringBuilder logMessages = new StringBuilder();
+
+        @Override
+        protected void append(ILoggingEvent eventObject) {
+            logMessages.append(eventObject.getFormattedMessage());
+        }
+
+        public boolean contains(String message) {
+            return logMessages.toString().contains(message);
+        }
     }
 }

--- a/di/src/test/java/samples/SampleController.java
+++ b/di/src/test/java/samples/SampleController.java
@@ -8,8 +8,16 @@ public class SampleController {
 
   private SampleService sampleService;
 
+  public SampleService getSampleService() {
+    return sampleService;
+  }
+
   @Autowired
   public SampleController(final SampleService sampleService) {
     this.sampleService = sampleService;
+  }
+
+  public void hello() {
+    sampleService.hello();
   }
 }

--- a/di/src/test/java/samples/SampleService.java
+++ b/di/src/test/java/samples/SampleService.java
@@ -4,4 +4,7 @@ import com.interface21.context.stereotype.Service;
 
 @Service
 public class SampleService {
+    public void hello() {
+        System.out.println("hello");
+    }
 }

--- a/di/src/test/java/samples/TestConfiguration.java
+++ b/di/src/test/java/samples/TestConfiguration.java
@@ -1,0 +1,9 @@
+package samples;
+
+import com.interface21.context.annotation.ComponentScan;
+import com.interface21.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan({ "samples" })
+public class TestConfiguration {
+}


### PR DESCRIPTION
아래와 같은 기능을 구현하였습니다

- bean 객체 생성시 필드에 세팅되는 객체들을 proxy 객체로 변경
- 필드의 메소드가 호출시 실제 빈객체를 불러오게 변경

![image](https://github.com/user-attachments/assets/ed7c765c-2332-4aa5-b278-7cf7c1cf15fc)

cglib 때문인지 모르겠지만 junit 환경에서 테스트를 실행해야 제대로 동작하며,

--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED

위의 옵션을 추가해야됩니다